### PR TITLE
Fix utf-8 letters in title and description

### DIFF
--- a/src/2.x/__init__.py
+++ b/src/2.x/__init__.py
@@ -102,8 +102,8 @@ def get_html():
 
     template = jinja2.Template(open(u"assets/index.jinja", u'r').read())
 
-    templateVars = { u"title" : unicode(config.get(u'head', u'title')),
-                     u"description" : unicode(config.get(u'head', u'description')),
+    templateVars = { u"title" : unicode(config.get(u'head', u'title').decode('utf-8')),
+                     u"description" : unicode(config.get(u'head', u'description').decode('utf-8')),
                      u"sections": get_sections() }
 
     return template.render(templateVars)


### PR DESCRIPTION
If default.cfg `title` or `description` has non-ascii characters in them, `hyhyhy build` will fail. This should fix it.
