### PR TITLE
Support for vim key mappings

### DIFF
--- a/lib/hyhyhy/structure/_assets/javascripts/main.js
+++ b/lib/hyhyhy/structure/_assets/javascripts/main.js
@@ -82,6 +82,8 @@
                     slide: slide,
                     next: step.bind(null, 1),
                     prev: step.bind(null, -1),
+                    first: slide.bind(null, 0),
+                    last: slide.bind(null, slides.length - 1),
                     parent: parent,
                     slides: slides
                 };
@@ -134,6 +136,8 @@
         slide: callOnAllDecks('slide'),
         next: callOnAllDecks('next'),
         prev: callOnAllDecks('prev'),
+        first: callOnAllDecks('first'),
+        last: callOnAllDecks('last'),
         plugins: plugins
     };
 
@@ -244,20 +248,44 @@ hyhyhy.plugins.hash = function(deck) {
 };
 
 hyhyhy.plugins.keys = function(deck, options) {
-    var isHorizontal = options === true || options == 'horizontal';
+    var isHorizontal = options === true || options == 'horizontal',
+        keyList = [];
+
+    var pushToQueue = function(list, limit, v) {
+        if (list.length === limit) {
+            list.splice(-2, 1);
+        }
+        list.push(v);
+        return list;
+    };
+
+    var isEqual = function(arr1, arr2) {
+      return JSON.stringify(arr1) === JSON.stringify(arr2);
+    };
 
     document.addEventListener('keydown', function(e) {
+        var withMod = e.shiftKey || e.altKey || e.ctrlKey || e.metaKey;
+
         (
             e.which == 34 || // PAGE DOWN
             e.which == 32 || // SPACE
+            e.which == 74 || // j
             isHorizontal && e.which == 39 || // RIGHT
             !isHorizontal && e.which == 40 // DOWN
         ) && deck.next();
         (
             e.which == 33 || // PAGE UP
+            e.which == 75 || // k
             isHorizontal && e.which == 37 || // LEFT
             !isHorizontal && e.which == 38 // UP
         ) && deck.prev();
+        (
+            // GG
+            isEqual([71, 71], pushToQueue(keyList, 2, !withMod ? e.which : null))
+        ) && deck.first();
+        (
+            e.which == 71 && e.shiftKey // SHIFT + G
+        ) && deck.last();
     });
 };
 


### PR DESCRIPTION
- Use `j` and `k` to navigation
- Use `gg` and `shift + g` to move to top/bottom